### PR TITLE
Add theme toggle and reposition quick help

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 GearLab Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# gears_app
+# GearLab
+
+GearLab és un simulador web interactiu d'engranatges inspirat en [gearsket.ch](https://gearsket.ch). L'aplicació et permet dibuixar engranatges amb el ratolí, connectar-los automàticament o amb cadenes, editar-ne les propietats i visualitzar com gira el conjunt amb relacions de transmissió calculades en temps real.
+
+## Funcionalitats principals
+
+- **Dibuix intuïtiu:** crea un engranatge dibuixant un cercle al canvas. El radi determina el nombre de dents inicials.
+- **Connexió automàtica:** els engranatges que es toquen lateralment es connecten i comparteixen la relació de transmissió correctament.
+- **Mode cadena:** connecta engranatges separats amb la mateixa direcció de gir utilitzant el mode cadena.
+- **Editor flotant:** clica un engranatge per obrir un popup amb nombre de dents, RPM i direcció de gir. Els canvis s'apliquen instantàniament.
+- **Simulació en temps real:** inicia la simulació per veure la rotació, línies de referència vermelles i etiquetes amb les relacions de transmissió.
+- **Gestió del canvas:** elimina engranatges concrets o reinicia tot el disseny amb un sol botó.
+
+## Posar-ho en marxa
+
+No cal cap servidor especial: n'hi ha prou amb obrir `index.html` en qualsevol navegador modern.
+
+Si prefereixes aixecar un servidor local:
+
+```bash
+python -m http.server 8000
+```
+
+I tot seguit visita `http://localhost:8000`.
+
+## Controls
+
+- **Dibuixar:** mantén el botó esquerre del ratolí i arrossega per establir el radi.
+- **Arrossegar:** clica sobre un engranatge existent i mou-lo.
+- **Editar:** clica sense arrossegar per obrir el panell d'edició.
+- **Mode cadena:** activa'l amb el botó corresponent i selecciona dos engranatges.
+- **Simulació:** utilitza el botó *Inicia simulació* / *Atura simulació*.
+- **Escapament ràpid:** prem `Esc` per tancar el panell o sortir del mode cadena.
+
+## Llicència
+
+Aquest projecte es distribueix sota la [llicència MIT](LICENSE).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="ca">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GearLab - Simulador d'engranatges</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body class="theme-dark" data-theme="dark">
+    <header class="app-header">
+      <h1>GearLab</h1>
+      <div class="header-controls">
+        <div class="primary-actions">
+          <button id="toggle-sim">Inicia simulació</button>
+          <button
+            type="button"
+            class="info-button"
+            id="quick-info"
+            aria-haspopup="dialog"
+            aria-expanded="false"
+            aria-controls="quick-info-popup"
+          >
+            <span aria-hidden="true">i</span>
+            <span class="sr-only">Mostra instruccions ràpides</span>
+          </button>
+          <button id="chain-mode">Mode cadena</button>
+          <button id="clear-all">Esborra tot</button>
+        </div>
+        <button
+          type="button"
+          id="theme-toggle"
+          class="theme-toggle"
+          aria-pressed="true"
+          aria-label="Canvia entre mode clar i mode fosc"
+        >
+          <span class="theme-icon theme-icon-sun" aria-hidden="true">☀️</span>
+          <span class="theme-icon theme-icon-moon" aria-hidden="true">🌙</span>
+          <span class="sr-only">Commuta mode de color</span>
+        </button>
+      </div>
+    </header>
+    <main>
+      <div
+        class="info-popup hidden"
+        id="quick-info-popup"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="quick-info-heading"
+        aria-hidden="true"
+        tabindex="-1"
+      >
+        <div class="info-popup-content">
+          <header class="info-popup-header">
+            <h3 id="quick-info-heading">Instruccions ràpides</h3>
+            <button type="button" class="info-popup-close" id="quick-info-close">
+              Tanca
+            </button>
+          </header>
+          <ul>
+            <li>Dibuixa un cercle amb el ratolí per crear un engranatge.</li>
+            <li>Arrossega un engranatge per moure'l pel canvas.</li>
+            <li>Clica un engranatge per editar-lo o esborrar-lo.</li>
+            <li>Els engranatges que es toquen es connecten automàticament.</li>
+            <li>Activa el mode cadena per connectar engranatges separats.</li>
+          </ul>
+        </div>
+      </div>
+      <section class="canvas-wrapper">
+        <canvas id="gear-canvas"></canvas>
+        <div id="gear-editor" class="gear-editor hidden">
+          <form>
+            <h3>Editar engranatge</h3>
+            <label>
+              Nombre de dents
+              <input type="number" id="gear-teeth" min="4" step="1" />
+            </label>
+            <label>
+              RPM
+              <input type="number" id="gear-rpm" step="1" />
+            </label>
+            <label class="toggle">
+              Direcció de gir
+              <div class="toggle-buttons">
+                <button type="button" data-direction="counterclockwise">&larr;</button>
+                <button type="button" data-direction="clockwise" class="active">&rarr;</button>
+              </div>
+            </label>
+            <div class="editor-actions">
+              <button type="button" id="delete-gear" class="danger">Elimina</button>
+              <button type="button" id="close-editor">Tanca</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="wrap footer-inner">
+        <div data-i18n="footer.license" data-i18n-type="html">
+          Generador Aleatori d'Exàmens © 2025 per
+          <a href="mailto:aagust11@xtec.cat">aagust11@xtec.cat</a> amb l'assistència de la IA està llicenciat sota
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>.
+        </div>
+        <div class="footer-meta">
+          <div data-i18n="footer.version">Versió 1 · Octubre 2025</div>
+
+          <div class="footer-icons">
+            <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons" />
+            <img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Reconeixement" />
+            <img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="No Comercial" />
+            <img src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Compartir Igual" />
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,633 @@
+const canvas = document.getElementById("gear-canvas");
+const ctx = canvas.getContext("2d");
+const wrapper = document.querySelector(".canvas-wrapper");
+const toggleSimBtn = document.getElementById("toggle-sim");
+const chainModeBtn = document.getElementById("chain-mode");
+const clearAllBtn = document.getElementById("clear-all");
+const editor = document.getElementById("gear-editor");
+const teethInput = document.getElementById("gear-teeth");
+const rpmInput = document.getElementById("gear-rpm");
+const directionButtons = editor.querySelectorAll(".toggle-buttons button");
+const deleteBtn = document.getElementById("delete-gear");
+const closeEditorBtn = document.getElementById("close-editor");
+const quickInfoBtn = document.getElementById("quick-info");
+const quickInfoPopup = document.getElementById("quick-info-popup");
+const quickInfoClose = document.getElementById("quick-info-close");
+const themeToggleBtn = document.getElementById("theme-toggle");
+
+let gears = [];
+let gearCounter = 1;
+let hoveredGear = null;
+let selectedGear = null;
+let drawing = false;
+let drawingStart = null;
+let previewRadius = 0;
+let draggingGear = null;
+let dragOffset = { x: 0, y: 0 };
+let dragMoved = false;
+let simulationRunning = false;
+let chainMode = false;
+let chainSelection = null;
+let lastTime = performance.now();
+let activeTheme = document.body?.dataset?.theme || "dark";
+
+const THEME_KEY = "gearlab-theme";
+const prefersDarkQuery =
+  typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-color-scheme: dark)")
+    : null;
+
+function applyTheme(theme) {
+  const normalized = theme === "light" ? "light" : "dark";
+  document.body.classList.remove("theme-light", "theme-dark");
+  document.body.classList.add(`theme-${normalized}`);
+  document.body.dataset.theme = normalized;
+  if (themeToggleBtn) {
+    themeToggleBtn.setAttribute("aria-pressed", normalized === "dark" ? "true" : "false");
+  }
+  activeTheme = normalized;
+}
+
+let storedTheme = null;
+try {
+  storedTheme = localStorage.getItem(THEME_KEY);
+} catch (error) {
+  console.warn("No es pot llegir la preferència de tema", error);
+}
+
+if (storedTheme) {
+  applyTheme(storedTheme);
+} else {
+  const prefersDark = prefersDarkQuery ? prefersDarkQuery.matches : true;
+  applyTheme(prefersDark ? "dark" : "light");
+}
+
+if (prefersDarkQuery) {
+  const handlePrefersChange = (event) => {
+    let savedTheme = null;
+    try {
+      savedTheme = localStorage.getItem(THEME_KEY);
+    } catch (error) {
+      console.warn("No es pot llegir la preferència de tema", error);
+    }
+    if (!savedTheme) {
+      applyTheme(event.matches ? "dark" : "light");
+    }
+  };
+
+  if (typeof prefersDarkQuery.addEventListener === "function") {
+    prefersDarkQuery.addEventListener("change", handlePrefersChange);
+  } else if (typeof prefersDarkQuery.addListener === "function") {
+    prefersDarkQuery.addListener(handlePrefersChange);
+  }
+}
+
+if (themeToggleBtn) {
+  themeToggleBtn.addEventListener("click", () => {
+    const nextTheme = activeTheme === "dark" ? "light" : "dark";
+    applyTheme(nextTheme);
+    try {
+      localStorage.setItem(THEME_KEY, nextTheme);
+    } catch (error) {
+      console.warn("No es pot guardar la preferència de tema", error);
+    }
+  });
+}
+
+function openQuickInfo() {
+  if (!quickInfoPopup) return;
+  quickInfoPopup.classList.remove("hidden");
+  quickInfoPopup.setAttribute("aria-hidden", "false");
+  if (quickInfoBtn) {
+    quickInfoBtn.setAttribute("aria-expanded", "true");
+  }
+  if (quickInfoClose) {
+    quickInfoClose.focus();
+  } else {
+    quickInfoPopup.focus();
+  }
+}
+
+function closeQuickInfo() {
+  if (!quickInfoPopup) return;
+  quickInfoPopup.classList.add("hidden");
+  quickInfoPopup.setAttribute("aria-hidden", "true");
+  if (quickInfoBtn) {
+    quickInfoBtn.setAttribute("aria-expanded", "false");
+    quickInfoBtn.focus();
+  }
+}
+
+function resizeCanvas() {
+  const rect = wrapper.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  canvas.style.width = `${rect.width}px`;
+  canvas.style.height = `${rect.height}px`;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
+window.addEventListener("resize", resizeCanvas);
+resizeCanvas();
+
+function toCanvasCoords(event) {
+  const rect = canvas.getBoundingClientRect();
+  return {
+    x: event.clientX - rect.left,
+    y: event.clientY - rect.top,
+  };
+}
+
+function createGear({ x, y, radius }) {
+  const baseTeeth = Math.max(6, Math.round(radius / 4) * 2);
+  const gear = {
+    id: `gear_${gearCounter++}`,
+    x,
+    y,
+    radius,
+    numTeeth: baseTeeth,
+    module: radius / baseTeeth,
+    rpm: null,
+    direction: "clockwise",
+    angle: 0,
+    connections: [],
+    effectiveRpm: null,
+    effectiveDir: null,
+    conflict: false,
+  };
+  gears.push(gear);
+  updateAutoConnections();
+  propagateRpm();
+}
+
+function getGearAt({ x, y }) {
+  return (
+    gears
+      .slice()
+      .reverse()
+      .find((gear) => Math.hypot(gear.x - x, gear.y - y) <= gear.radius + 8) || null
+  );
+}
+
+function ensureConnection(a, b, type) {
+  if (!a.connections.some((c) => c.id === b.id && c.type === type)) {
+    a.connections.push({ id: b.id, type });
+  }
+  if (!b.connections.some((c) => c.id === a.id && c.type === type)) {
+    b.connections.push({ id: a.id, type });
+  }
+}
+
+function detachGear(gear) {
+  gears.forEach((g) => {
+    g.connections = g.connections.filter((conn) => conn.id !== gear.id);
+  });
+}
+
+function updateAutoConnections() {
+  gears.forEach((gear) => {
+    gear.connections = gear.connections.filter((conn) => conn.type !== "mesh");
+  });
+
+  for (let i = 0; i < gears.length; i += 1) {
+    for (let j = i + 1; j < gears.length; j += 1) {
+      const g1 = gears[i];
+      const g2 = gears[j];
+      const dx = g1.x - g2.x;
+      const dy = g1.y - g2.y;
+      const distance = Math.hypot(dx, dy);
+      const expected = g1.radius + g2.radius;
+      if (distance > 0 && Math.abs(distance - expected) <= 8) {
+        ensureConnection(g1, g2, "mesh");
+      }
+    }
+  }
+}
+
+function propagateRpm() {
+  const queue = [];
+  gears.forEach((gear) => {
+    gear.effectiveRpm = gear.rpm != null ? Number(gear.rpm) : null;
+    gear.effectiveDir = gear.rpm != null ? (gear.direction === "clockwise" ? 1 : -1) : null;
+    gear.conflict = false;
+    if (gear.effectiveRpm != null && !Number.isNaN(gear.effectiveRpm)) {
+      queue.push(gear);
+    }
+  });
+
+  while (queue.length > 0) {
+    const gear = queue.shift();
+    const baseRpm = gear.effectiveRpm ?? 0;
+    const baseDir = gear.effectiveDir ?? 1;
+    gear.connections.forEach((conn) => {
+      const neighbor = gears.find((g) => g.id === conn.id);
+      if (!neighbor) return;
+      const ratio = gear.numTeeth / neighbor.numTeeth;
+      const directionFactor = conn.type === "mesh" ? -1 : 1;
+      const computedRpm = baseRpm * ratio;
+      const computedDir = baseDir * directionFactor;
+
+      if (neighbor.effectiveRpm == null) {
+        neighbor.effectiveRpm = computedRpm;
+        neighbor.effectiveDir = computedDir;
+        queue.push(neighbor);
+      } else {
+        if (Math.abs(neighbor.effectiveRpm - computedRpm) > 0.5) {
+          neighbor.conflict = true;
+        }
+      }
+    });
+  }
+}
+
+function openEditor(gear) {
+  selectedGear = gear;
+  editor.classList.remove("hidden");
+  const wrapperRect = wrapper.getBoundingClientRect();
+  const left = Math.min(Math.max(gear.x + 16, 12), wrapperRect.width - 260);
+  const top = Math.min(Math.max(gear.y - 20, 12), wrapperRect.height - 220);
+  editor.style.left = `${left}px`;
+  editor.style.top = `${top}px`;
+  teethInput.value = gear.numTeeth;
+  rpmInput.value = gear.rpm != null ? gear.rpm : "";
+  directionButtons.forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.direction === gear.direction);
+  });
+}
+
+function closeEditor() {
+  editor.classList.add("hidden");
+  selectedGear = null;
+}
+
+canvas.addEventListener("mousedown", (event) => {
+  if (event.button !== 0) return;
+  const point = toCanvasCoords(event);
+  const gear = getGearAt(point);
+  dragMoved = false;
+
+  if (gear && !drawing) {
+    draggingGear = gear;
+    dragOffset = { x: point.x - gear.x, y: point.y - gear.y };
+    return;
+  }
+
+  drawing = true;
+  drawingStart = point;
+  previewRadius = 0;
+  closeEditor();
+});
+
+canvas.addEventListener("mousemove", (event) => {
+  const point = toCanvasCoords(event);
+  hoveredGear = getGearAt(point);
+
+  if (drawing && drawingStart) {
+    previewRadius = Math.max(10, Math.hypot(point.x - drawingStart.x, point.y - drawingStart.y));
+    return;
+  }
+
+  if (draggingGear) {
+    dragMoved = true;
+    draggingGear.x = point.x - dragOffset.x;
+    draggingGear.y = point.y - dragOffset.y;
+    updateAutoConnections();
+    propagateRpm();
+  }
+});
+
+canvas.addEventListener("mouseup", (event) => {
+  if (event.button !== 0) return;
+  const point = toCanvasCoords(event);
+
+  if (draggingGear) {
+    const wasDragged = dragMoved;
+    const gear = draggingGear;
+    draggingGear = null;
+    dragOffset = { x: 0, y: 0 };
+    updateAutoConnections();
+    propagateRpm();
+
+    if (!wasDragged) {
+      if (chainMode) {
+        handleChainSelection(gear);
+      } else {
+        openEditor(gear);
+      }
+    }
+    return;
+  }
+
+  if (drawing) {
+    drawing = false;
+    const radius = Math.max(16, previewRadius);
+    if (radius >= 16) {
+      createGear({ x: drawingStart.x, y: drawingStart.y, radius });
+    }
+    drawingStart = null;
+    previewRadius = 0;
+  }
+});
+
+canvas.addEventListener("mouseleave", () => {
+  if (draggingGear) {
+    draggingGear = null;
+    dragOffset = { x: 0, y: 0 };
+  }
+  drawing = false;
+  drawingStart = null;
+  previewRadius = 0;
+  hoveredGear = null;
+});
+
+function handleChainSelection(gear) {
+  if (!chainSelection) {
+    chainSelection = gear;
+  } else if (chainSelection.id !== gear.id) {
+    ensureConnection(chainSelection, gear, "chain");
+    chainSelection = null;
+    propagateRpm();
+  } else {
+    chainSelection = null;
+  }
+}
+
+teethInput.addEventListener("change", () => {
+  if (!selectedGear) return;
+  const value = Math.max(4, Number.parseInt(teethInput.value, 10));
+  if (Number.isNaN(value)) return;
+  selectedGear.numTeeth = value;
+  const targetRadius = Math.max(16, selectedGear.module * selectedGear.numTeeth);
+  selectedGear.radius = targetRadius;
+  updateAutoConnections();
+  propagateRpm();
+});
+
+rpmInput.addEventListener("input", () => {
+  if (!selectedGear) return;
+  const value = rpmInput.value.trim();
+  if (value === "") {
+    selectedGear.rpm = null;
+  } else {
+    const numeric = Number.parseFloat(value);
+    selectedGear.rpm = Number.isNaN(numeric) ? null : numeric;
+  }
+  propagateRpm();
+});
+
+directionButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    if (!selectedGear) return;
+    selectedGear.direction = button.dataset.direction;
+    directionButtons.forEach((btn) => btn.classList.toggle("active", btn === button));
+    propagateRpm();
+  });
+});
+
+deleteBtn.addEventListener("click", () => {
+  if (!selectedGear) return;
+  const target = selectedGear;
+  closeEditor();
+  detachGear(target);
+  gears = gears.filter((g) => g.id !== target.id);
+  updateAutoConnections();
+  propagateRpm();
+});
+
+closeEditorBtn.addEventListener("click", closeEditor);
+
+if (quickInfoBtn && quickInfoPopup) {
+  quickInfoBtn.addEventListener("click", () => {
+    const isHidden = quickInfoPopup.classList.contains("hidden");
+    if (isHidden) {
+      openQuickInfo();
+    } else {
+      closeQuickInfo();
+    }
+  });
+}
+
+if (quickInfoClose) {
+  quickInfoClose.addEventListener("click", closeQuickInfo);
+}
+
+if (quickInfoPopup) {
+  quickInfoPopup.addEventListener("click", (event) => {
+    if (event.target === quickInfoPopup) {
+      closeQuickInfo();
+    }
+  });
+}
+
+clearAllBtn.addEventListener("click", () => {
+  gears = [];
+  chainSelection = null;
+  closeEditor();
+  updateAutoConnections();
+  propagateRpm();
+});
+
+chainModeBtn.addEventListener("click", () => {
+  chainMode = !chainMode;
+  chainSelection = null;
+  chainModeBtn.classList.toggle("active", chainMode);
+});
+
+toggleSimBtn.addEventListener("click", () => {
+  simulationRunning = !simulationRunning;
+  toggleSimBtn.textContent = simulationRunning ? "Atura simulació" : "Inicia simulació";
+  toggleSimBtn.classList.toggle("active", simulationRunning);
+});
+
+function drawConnections() {
+  ctx.save();
+  ctx.lineWidth = 2;
+  gears.forEach((gear) => {
+    gear.connections.forEach((conn) => {
+      const neighbor = gears.find((g) => g.id === conn.id);
+      if (!neighbor) return;
+      if (gear.id > neighbor.id) return;
+      ctx.beginPath();
+      if (conn.type === "mesh") {
+        ctx.setLineDash([]);
+        ctx.strokeStyle = "rgba(79, 195, 247, 0.35)";
+      } else {
+        ctx.setLineDash([8, 6]);
+        ctx.strokeStyle = "rgba(255, 184, 108, 0.65)";
+      }
+      ctx.moveTo(gear.x, gear.y);
+      ctx.lineTo(neighbor.x, neighbor.y);
+      ctx.stroke();
+
+      const midX = (gear.x + neighbor.x) / 2;
+      const midY = (gear.y + neighbor.y) / 2;
+      const ratio = gear.numTeeth / neighbor.numTeeth;
+      const ratioText = `${gear.numTeeth} : ${neighbor.numTeeth} = ${ratio.toFixed(2)} : 1`;
+      ctx.save();
+      ctx.translate(midX, midY - 10);
+      ctx.fillStyle = "rgba(6, 9, 15, 0.85)";
+      ctx.strokeStyle = "rgba(255, 255, 255, 0.25)";
+      ctx.lineWidth = 2;
+      const paddingX = 10;
+      const paddingY = 6;
+      ctx.font = "12px 'Inter', sans-serif";
+      const textWidth = ctx.measureText(ratioText).width;
+      const rectX = -textWidth / 2 - paddingX;
+      const rectY = -paddingY - 8;
+      const rectWidth = textWidth + paddingX * 2;
+      const rectHeight = 22;
+      const radius = 12;
+      ctx.beginPath();
+      if (typeof ctx.roundRect === "function") {
+        ctx.roundRect(rectX, rectY, rectWidth, rectHeight, radius);
+      } else {
+        const r = Math.min(radius, rectWidth / 2, rectHeight / 2);
+        ctx.moveTo(rectX + r, rectY);
+        ctx.lineTo(rectX + rectWidth - r, rectY);
+        ctx.quadraticCurveTo(rectX + rectWidth, rectY, rectX + rectWidth, rectY + r);
+        ctx.lineTo(rectX + rectWidth, rectY + rectHeight - r);
+        ctx.quadraticCurveTo(rectX + rectWidth, rectY + rectHeight, rectX + rectWidth - r, rectY + rectHeight);
+        ctx.lineTo(rectX + r, rectY + rectHeight);
+        ctx.quadraticCurveTo(rectX, rectY + rectHeight, rectX, rectY + rectHeight - r);
+        ctx.lineTo(rectX, rectY + r);
+        ctx.quadraticCurveTo(rectX, rectY, rectX + r, rectY);
+      }
+      ctx.fill();
+      ctx.stroke();
+      ctx.fillStyle = "#f5f7fb";
+      ctx.fillText(ratioText, -textWidth / 2, 6);
+      ctx.restore();
+    });
+  });
+  ctx.restore();
+}
+
+function drawGear(gear) {
+  ctx.save();
+  const highlight = gear === hoveredGear || gear === selectedGear || gear === chainSelection;
+  const fillGradient = ctx.createRadialGradient(gear.x - gear.radius * 0.3, gear.y - gear.radius * 0.3, gear.radius * 0.2, gear.x, gear.y, gear.radius * 1.2);
+  fillGradient.addColorStop(0, "rgba(79, 195, 247, 0.35)");
+  fillGradient.addColorStop(1, "rgba(20, 26, 40, 0.95)");
+  ctx.fillStyle = fillGradient;
+  ctx.strokeStyle = highlight ? "rgba(255, 184, 108, 0.85)" : "rgba(255, 255, 255, 0.28)";
+  ctx.lineWidth = highlight ? 3 : 2;
+
+  ctx.beginPath();
+  ctx.arc(gear.x, gear.y, gear.radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.save();
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.5)";
+  ctx.lineWidth = 1.2;
+  for (let i = 0; i < gear.numTeeth; i += 1) {
+    const angle = (i / gear.numTeeth) * Math.PI * 2 + gear.angle;
+    const inner = gear.radius - 4;
+    const outer = gear.radius + 6;
+    const x1 = gear.x + Math.cos(angle) * inner;
+    const y1 = gear.y + Math.sin(angle) * inner;
+    const x2 = gear.x + Math.cos(angle) * outer;
+    const y2 = gear.y + Math.sin(angle) * outer;
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  ctx.beginPath();
+  ctx.strokeStyle = "#ff5c5c";
+  ctx.lineWidth = 2.5;
+  const pointerX = gear.x + Math.cos(gear.angle) * gear.radius;
+  const pointerY = gear.y + Math.sin(gear.angle) * gear.radius;
+  ctx.moveTo(gear.x, gear.y);
+  ctx.lineTo(pointerX, pointerY);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.fillStyle = "rgba(255, 255, 255, 0.85)";
+  ctx.arc(gear.x, gear.y, 4, 0, Math.PI * 2);
+  ctx.fill();
+
+  const rpmDisplay = gear.effectiveRpm != null ? `${gear.effectiveRpm.toFixed(1)} rpm` : "-";
+  const directionSymbol = gear.effectiveDir == null ? "" : gear.effectiveDir > 0 ? "\u27F6" : "\u27F5";
+  const conflictText = gear.conflict ? "!" : "";
+  const label = `${gear.numTeeth} dents • ${rpmDisplay} ${directionSymbol} ${conflictText}`.trim();
+
+  ctx.font = "12px 'Inter', sans-serif";
+  ctx.fillStyle = "rgba(255, 255, 255, 0.9)";
+  ctx.textAlign = "center";
+  ctx.fillText(label, gear.x, gear.y + gear.radius + 18);
+
+  ctx.restore();
+}
+
+function drawPreview() {
+  if (drawing && drawingStart && previewRadius > 0) {
+    ctx.save();
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.35)";
+    ctx.setLineDash([6, 6]);
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.arc(drawingStart.x, drawingStart.y, previewRadius, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  if (chainMode && chainSelection && hoveredGear && hoveredGear.id !== chainSelection.id) {
+    ctx.save();
+    ctx.setLineDash([8, 4]);
+    ctx.strokeStyle = "rgba(255, 184, 108, 0.8)";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(chainSelection.x, chainSelection.y);
+    ctx.lineTo(hoveredGear.x, hoveredGear.y);
+    ctx.stroke();
+    ctx.restore();
+  }
+}
+
+function update(delta) {
+  propagateRpm();
+  if (simulationRunning) {
+    gears.forEach((gear) => {
+      const rpm = gear.effectiveRpm ?? 0;
+      const direction = gear.effectiveDir ?? (gear.direction === "clockwise" ? 1 : -1);
+      const angularVelocity = (rpm * Math.PI * 2) / 60 * direction;
+      gear.angle += angularVelocity * delta;
+    });
+  }
+}
+
+function render() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawConnections();
+  gears.forEach((gear) => drawGear(gear));
+  drawPreview();
+}
+
+function loop(time) {
+  const delta = (time - lastTime) / 1000;
+  lastTime = time;
+  update(delta);
+  render();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);
+
+window.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    if (quickInfoPopup && !quickInfoPopup.classList.contains("hidden")) {
+      closeQuickInfo();
+      return;
+    }
+    if (chainMode) {
+      chainMode = false;
+      chainSelection = null;
+      chainModeBtn.classList.remove("active");
+    }
+    closeEditor();
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,439 @@
+:root {
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--app-background);
+  color: var(--text);
+  transition: background 0.35s ease, color 0.35s ease;
+}
+
+body.theme-dark {
+  color-scheme: dark;
+  --app-background: radial-gradient(circle at top, #1c2333, #0b0d15 65%);
+  --header-bg: rgba(4, 6, 10, 0.85);
+  --panel: rgba(255, 255, 255, 0.06);
+  --panel-border: rgba(255, 255, 255, 0.12);
+  --panel-soft: rgba(255, 255, 255, 0.05);
+  --panel-strong: rgba(6, 9, 15, 0.95);
+  --overlay: rgba(4, 6, 10, 0.65);
+  --text: #f5f7fb;
+  --text-muted: rgba(245, 247, 251, 0.7);
+  --accent: #ff5c5c;
+  --accent-2: #4fc3f7;
+  --canvas-surface: rgba(10, 13, 20, 0.75);
+  --grid-dot-color: rgba(255, 255, 255, 0.02);
+  --grid-glow: rgba(79, 195, 247, 0.08);
+  --popup-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+  --footer-bg: rgba(4, 6, 10, 0.85);
+  --icon-filter: drop-shadow(0 0 6px rgba(79, 195, 247, 0.3));
+}
+
+body.theme-light {
+  color-scheme: light;
+  --app-background: radial-gradient(circle at top, #f5f7ff, #d9e1ff 65%);
+  --header-bg: rgba(255, 255, 255, 0.85);
+  --panel: rgba(27, 36, 48, 0.08);
+  --panel-border: rgba(27, 36, 48, 0.16);
+  --panel-soft: rgba(27, 36, 48, 0.06);
+  --panel-strong: rgba(255, 255, 255, 0.92);
+  --overlay: rgba(10, 14, 25, 0.35);
+  --text: #1b2430;
+  --text-muted: rgba(27, 36, 48, 0.7);
+  --accent: #ff5c5c;
+  --accent-2: #2d7dd2;
+  --canvas-surface: rgba(255, 255, 255, 0.85);
+  --grid-dot-color: rgba(27, 36, 48, 0.05);
+  --grid-glow: rgba(79, 195, 247, 0.14);
+  --popup-shadow: 0 24px 48px rgba(57, 75, 99, 0.2);
+  --footer-bg: rgba(255, 255, 255, 0.85);
+  --icon-filter: none;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 2rem;
+  border-bottom: 1px solid var(--panel-border);
+  background: var(--header-bg);
+  backdrop-filter: blur(12px);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+button {
+  font-family: inherit;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.primary-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.primary-actions button,
+.info-popup-close,
+.editor-actions button,
+.toggle .toggle-buttons button {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  color: var(--text);
+  font-weight: 600;
+  transition: transform 0.18s ease, background 0.18s ease, border 0.18s ease;
+}
+
+.primary-actions button {
+  padding: 0.55rem 1.1rem;
+  border-radius: 0.75rem;
+  cursor: pointer;
+}
+
+.primary-actions button:hover,
+.primary-actions button.active {
+  background: rgba(79, 195, 247, 0.2);
+  border-color: var(--accent-2);
+  transform: translateY(-2px);
+}
+
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem;
+}
+
+.info-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: rgba(79, 195, 247, 0.18);
+  color: var(--text);
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, border 0.2s ease;
+}
+
+.info-button:hover,
+.info-button:focus-visible {
+  background: rgba(79, 195, 247, 0.32);
+  border-color: rgba(79, 195, 247, 0.7);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.info-popup {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 30;
+  backdrop-filter: blur(6px);
+}
+
+.info-popup-content {
+  width: min(420px, 100%);
+  background: var(--panel-strong);
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: var(--popup-shadow);
+  display: grid;
+  gap: 1rem;
+}
+
+.info-popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.info-popup h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.info-popup ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+}
+
+.info-popup-close {
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  cursor: pointer;
+}
+
+.info-popup-close:hover,
+.info-popup-close:focus-visible {
+  background: rgba(79, 195, 247, 0.25);
+  border-color: rgba(79, 195, 247, 0.6);
+  outline: none;
+}
+
+.canvas-wrapper {
+  position: relative;
+  flex: 1;
+  background: var(--canvas-surface);
+  border: 1px solid var(--panel-border);
+  border-radius: 1.2rem;
+  overflow: hidden;
+}
+
+#gear-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  background: repeating-radial-gradient(
+      circle at center,
+      var(--grid-dot-color) 0,
+      var(--grid-dot-color) 3px,
+      transparent 3px,
+      transparent 6px
+    ),
+    radial-gradient(circle at center, var(--grid-glow), transparent);
+}
+
+.gear-editor {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  background: var(--panel-strong);
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  width: 240px;
+  box-shadow: var(--popup-shadow);
+  z-index: 5;
+}
+
+.gear-editor.hidden {
+  display: none;
+}
+
+.gear-editor form {
+  display: grid;
+  gap: 1rem;
+}
+
+.gear-editor label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.gear-editor input {
+  background: var(--panel-soft);
+  border: 1px solid var(--panel-border);
+  border-radius: 0.6rem;
+  padding: 0.45rem 0.6rem;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.toggle .toggle-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.toggle .toggle-buttons button {
+  padding: 0.45rem 0.8rem;
+  border-radius: 0.55rem;
+  cursor: pointer;
+  background: var(--panel-soft);
+}
+
+.toggle .toggle-buttons button.active {
+  background: rgba(255, 92, 92, 0.2);
+  border-color: var(--accent);
+}
+
+.editor-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.editor-actions button {
+  flex: 1;
+  padding: 0.55rem;
+  border-radius: 0.65rem;
+  cursor: pointer;
+  background: var(--panel-soft);
+}
+
+.editor-actions button.danger {
+  background: rgba(255, 92, 92, 0.18);
+  border-color: rgba(255, 92, 92, 0.5);
+}
+
+.site-footer {
+  padding: 2rem 2rem 2.5rem;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  border-top: 1px solid var(--panel-border);
+  background: var(--footer-bg);
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.footer-inner a {
+  color: var(--accent-2);
+}
+
+.footer-meta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3cm;
+  flex-wrap: wrap;
+}
+
+.footer-icons {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.footer-icons img {
+  width: 26px;
+  height: 26px;
+  filter: var(--icon-filter);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(79, 195, 247, 0.12);
+  border: 1px solid rgba(79, 195, 247, 0.4);
+  font-size: 0.75rem;
+}
+
+.connection-label {
+  position: absolute;
+  pointer-events: none;
+  background: var(--panel-strong);
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.chain-preview {
+  position: absolute;
+  pointer-events: none;
+  border: 1px dashed rgba(79, 195, 247, 0.8);
+  border-radius: 999px;
+}
+
+@media (max-width: 900px) {
+  .canvas-wrapper {
+    min-height: 420px;
+  }
+
+  .footer-inner {
+    justify-content: center;
+    text-align: center;
+  }
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  background: rgba(79, 195, 247, 0.2);
+  border-color: var(--accent-2);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.theme-toggle .theme-icon {
+  display: none;
+  font-size: 1.2rem;
+}
+
+body.theme-light .theme-toggle .theme-icon-sun,
+body.theme-dark .theme-toggle .theme-icon-moon {
+  display: inline;
+}


### PR DESCRIPTION
## Summary
- build GearLab single-page app with toolbar, help panel, and canvas-based editor
- implement gear drawing, connection logic, RPM propagation, and animated simulation with chains
- document usage in a new README and ship an MIT license
- add quick-help popup trigger and Creative Commons footer licensing details
- introduce a theme toggle, move the quick-help icon beside Inicia simulació, and center the Creative Commons footer with the requested spacing

## Testing
- ✅ `python -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68e0cc090e7c83249719472491147989